### PR TITLE
Update queries.go

### DIFF
--- a/queries.go
+++ b/queries.go
@@ -31,8 +31,8 @@ func (c SASTClient) GetQueriesSOAP() (QueryCollection, error) {
 							Language        uint64
 							LanguageName    string
 							PackageTypeName string
-							ProjectID       uint64
-							OwningTeam      uint64
+							ProjectID       int64
+							OwningTeam      int64
 						} `xml:"CxWSQueryGroup"`
 					}
 				}


### PR DESCRIPTION
When a project or a team is deleted, any associated query gets "orphan". At least for the project, the ProjectId reference is set to -1. Therefore the type to accommodate it must signed (int64 instead of  uint64)